### PR TITLE
ENH: Build dependency graph from single request.

### DIFF
--- a/dtool_gui/LookupClient.py
+++ b/dtool_gui/LookupClient.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Lars Pastewka
+# Copyright 2020 Lars Pastewka, Johannes Hoermann
 #
 # ### MIT license
 #
@@ -71,6 +71,14 @@ class LookupClient:
         """Search for a specific uuid"""
         async with self.session.get(
                 f'{self.lookup_url}/dataset/lookup/{uuid}',
+                headers=self.header,
+                verify_ssl=False) as r:
+            return await r.json()
+
+    async def graph(self, uuid):
+        """Request dependency graph for specific uuid"""
+        async with self.session.get(
+                f'{self.lookup_url}/dataset/graph/{uuid}',
                 headers=self.header,
                 verify_ssl=False) as r:
             return await r.json()


### PR DESCRIPTION
This branch is using the server's `dataset/graph` route for directly querying the dependency graph instead of building it on the client's side. You might want to offer both options in case the sever has this feature deactivated (?).

The following zipped notebook illustrates that at least for the treated test case the implemented mechanism works as expected:

[20200908_dtool_dataset_dependency_graph_via_dtool_gui.zip](https://github.com/IMTEK-Simulation/dtool-gui/files/5188241/20200908_dtool_dataset_dependency_graph_via_dtool_gui.zip)

However, for many (large) graphs, the layouter throws the following error:

```
(__main__.py:27850): Gtk-WARNING **: 13:37:48.950: drawing failure for widget 'dtool_gui+GraphWidget+GraphWidget': invalid matrix (not invertible)

(__main__.py:27850): Gtk-WARNING **: 13:37:48.950: drawing failure for widget 'GtkBox': invalid matrix (not invertible)

(__main__.py:27850): Gtk-WARNING **: 13:37:48.950: drawing failure for widget 'GtkStack': invalid matrix (not invertible)

(__main__.py:27850): Gtk-WARNING **: 13:37:48.950: drawing failure for widget 'GtkNotebook': invalid matrix (not invertible)

(__main__.py:27850): Gtk-WARNING **: 13:37:48.950: drawing failure for widget 'GtkPaned': invalid matrix (not invertible)

(__main__.py:27850): Gtk-WARNING **: 13:37:48.950: drawing failure for widget 'GtkStack': invalid matrix (not invertible)

(__main__.py:27850): Gtk-WARNING **: 13:37:48.950: drawing failure for widget 'GtkBox': invalid matrix (not invertible)

(__main__.py:27850): Gtk-WARNING **: 13:37:48.950: drawing failure for widget 'GtkApplicationWindow': invalid matrix (not invertible)
Traceback (most recent call last):
  File "/home/jotelha/venv/jlh-imtek-nb-python-3.6/lib/python3.6/site-packages/dtool_gui/GraphWidget.py", line 97, in on_draw
    self._cairo_scale(area, context)
  File "/home/jotelha/venv/jlh-imtek-nb-python-3.6/lib/python3.6/site-packages/dtool_gui/GraphWidget.py", line 85, in _cairo_scale
    context.scale(s, s)
cairo.Error: invalid matrix (not invertible)
```